### PR TITLE
docs: upload a short math symbols list

### DIFF
--- a/LaTeX/MathSymbolsList.tm
+++ b/LaTeX/MathSymbolsList.tm
@@ -1,0 +1,85 @@
+<TeXmacs|2.1.3>
+
+<style|<tuple|generic|doc>>
+
+<\body>
+  <doc-data|<doc-title|Math Symbols List>|>
+
+  <\big-table|<tabular|<tformat|<table|<row|<cell|<math|\<alpha\>>>|<cell|<verbatim|\\alpha>>|<cell|<key|a
+  Tab>>|<cell|>|<cell|<math|\<theta\>>>|<cell|<verbatim|\\theta>>|<cell|<key|j
+  Tab>>|<cell|>|<cell|<math|\<omicron\>>>|<cell|<verbatim|o>>|<cell|<verbatim|o>>>|<row|<cell|<math|\<tau\>>>|<cell|<verbatim|\\tau>>|<cell|<key|t
+  Tab>>|<cell|>|<cell|<math|\<beta\>>>|<cell|<verbatim|\\beta>>|<cell|<key|b
+  Tab>>|<cell|>|<cell|<math|\<vartheta\>>>|<cell|<verbatim|\\vartheta>>|<cell|<key|j
+  Tab Tab Tab>>>|<row|<cell|<math|\<pi\>>>|<cell|<verbatim|\\pi>>|<cell|<key|p
+  Tab>>|<cell|>|<cell|<math|\<upsilon\>>>|<cell|<verbatim|\\upsilon>>|<cell|<key|u
+  Tab>>|<cell|>|<cell|<math|\<gamma\>>>|<cell|<verbatim|\\gamma>>|<cell|<key|g
+  Tab>>>|<row|<cell|<math|\<iota\>>>|<cell|<verbatim|\\iota>>|<cell|<key|i
+  Tab>>|<cell|>|<cell|<math|\<varpi\>>>|<cell|<verbatim|\\varpi>>|<cell|<key|p
+  Tab Tab Tab>>|<cell|>|<cell|<math|\<phi\>>>|<cell|<verbatim|\\phi>>|<cell|<key|f
+  Tab Tab>>>|<row|<cell|<math|\<delta\>>>|<cell|<verbatim|\\delta>>|<cell|<key|d
+  Tab>>|<cell|>|<cell|<math|\<kappa\>>>|<cell|<verbatim|\\kappa>>|<cell|<key|k
+  Tab>>|<cell|>|<cell|<math|\<rho\>>>|<cell|<verbatim|\\rho>>|<cell|<key|r
+  Tab>>>|<row|<cell|<math|\<varphi\>>>|<cell|<verbatim|\\varphi>>|<cell|<key|f
+  Tab>>|<cell|>|<cell|<math|\<epsilon\>>>|<cell|<verbatim|\\epsilon>>|<cell|<key|e
+  Tab Tab Tab>>|<cell|>|<cell|<math|\<lambda\>>>|<cell|<verbatim|\\lambda>>|<cell|<key|l
+  Tab>>>|<row|<cell|<math|\<varrho\>>>|<cell|<verbatim|\\varrho>>|<cell|<key|r
+  Tab Tab>>|<cell|>|<cell|<math|\<chi\>>>|<cell|<verbatim|\\chi>>|<cell|<key|q
+  Tab>>|<cell|>|<cell|<math|\<varepsilon\>>>|<cell|<verbatim|\\varepsilon>>|<cell|<key|e
+  Tab>>>|<row|<cell|<math|\<mu\>>>|<cell|<verbatim|\\mu>>|<cell|<key|m
+  Tab>>|<cell|>|<cell|<math|\<sigma\>>>|<cell|<verbatim|\\sigma>>|<cell|<key|s
+  Tab>>|<cell|>|<cell|<math|\<psi\>>>|<cell|<verbatim|\\psi>>|<cell|<key|y
+  Tab>>>|<row|<cell|<math|\<zeta\>>>|<cell|<verbatim|\\zeta>>|<cell|<key|z
+  Tab>>|<cell|>|<cell|<math|\<nu\>>>|<cell|<verbatim|\\nu>>|<cell|<key|n
+  Tab>>|<cell|>|<cell|<math|\<varsigma\>>>|<cell|<verbatim|\\varsigma>>|<cell|<key|s
+  Tab Tab>>>|<row|<cell|<math|\<omega\>>>|<cell|<verbatim|\\omega>>|<cell|<key|w
+  Tab>>|<cell|>|<cell|<math|\<eta\>>>|<cell|<verbatim|\\eta>>|<cell|<key|h
+  Tab>>|<cell|>|<cell|<math|\<xi\>>>|<cell|<verbatim|\\xi>>|<cell|<key|x
+  Tab>>>|<row|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>|<cell|>>|<row|<cell|<math|\<Gamma\>>>|<cell|<verbatim|\\Gamma>>|<cell|<key|g
+  Tab>>|<cell|>|<cell|<math|\<Lambda\>>>|<cell|<verbatim|\\Lambda>>|<cell|<key|l
+  Tab>>|<cell|>|<cell|<math|\<Sigma\>>>|<cell|<verbatim|\\Sigma>>|<cell|<key|s
+  Tab>>>|<row|<cell|<math|\<Psi\>>>|<cell|<verbatim|\\Psi>>|<cell|<key|y
+  Tab>>|<cell|>|<cell|<math|\<Delta\>>>|<cell|<verbatim|\\Delta>>|<cell|<key|d
+  Tab>>|<cell|>|<cell|<math|\<Xi\>>>|<cell|<verbatim|\\Xi>>|<cell|<key|x
+  Tab>>>|<row|<cell|<math|\<Upsilon\>>>|<cell|<verbatim|\\Upsilon>>|<cell|<key|u
+  Tab>>|<cell|>|<cell|<math|\<Omega\>>>|<cell|<verbatim|\\Omega>>|<cell|<key|w
+  Tab>>|<cell|>|<cell|<math|\<Theta\>>>|<cell|<verbatim|\\Theta>>|<cell|<key|j
+  Tab>>>|<row|<cell|<math|\<Pi\>>>|<cell|<verbatim|\\Pi>>|<cell|<key|p
+  Tab>>|<cell|>|<cell|<math|\<Phi\>>>|<cell|<verbatim|\\Phi>>|<cell|<key|f
+  Tab>>|<cell|>|<cell|>|<cell|>|<cell|>>>>>>
+    Greek Letters
+  </big-table>
+
+  <\big-table|<tabular|<tformat|<table|<row|<cell|<math|\<pm\>>>|<cell|<verbatim|\\pm>>|<cell|<key|+->>|<cell|>|<cell|<math|\<cap\>>>|<cell|<verbatim|\\cap>>|<cell|<key|&
+  Tab>>|<cell|<math|>>|<cell|<math|\<diamond\>>>|<cell|<verbatim|\\diamond>>|<cell|>>|<row|<cell|<math|\<oplus\>>>|<cell|<verbatim|\\oplus>>|<cell|<key|@
+  +>>|<cell|>|<cell|<math|\<mp\>>>|<cell|<verbatim|\\mp>>|<cell|<key|-+>>|<cell|>|<cell|<math|>>|<cell|>|<cell|>>>>>>
+    Binary Operation Symbols
+  </big-table>
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-medium|paper>
+  </collection>
+</initial>
+
+<\references>
+  <\collection>
+    <associate|auto-1|<tuple|1|1>>
+    <associate|auto-2|<tuple|2|1>>
+    <associate|auto-3|<tuple|3|?>>
+  </collection>
+</references>
+
+<\auxiliary>
+  <\collection>
+    <\associate|table>
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|1>|>
+        <with|font-base-size|<quote|9>|>Greek Letters
+      </surround>|<pageref|auto-1>>
+
+      <tuple|normal|<\surround|<hidden-binding|<tuple>|2>|>
+        \;
+      </surround>|<pageref|auto-2>>
+    </associate>
+  </collection>
+</auxiliary>


### PR DESCRIPTION
目前已经完成了第一个希腊字母表，碰到了以下问题：
1. key 中不区分大小写字母，故记录的希腊字母快捷输入可能会产生混淆。
2. 部分符号没有快捷输入方式。
3. 部分符号与 LaTex 样式不同，例如 \bigtriangleup，可能是字体原因。

另外部分表已有相关文档了，例如 Binary Operation Symbols。